### PR TITLE
Don't include top-level "extra files" in the Xcode project.

### DIFF
--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -27,7 +27,7 @@ struct Command: ParsableCommand {
 
             Supported platforms: \(TargetPlatform.allCases.map({ $0.rawValue }).joined(separator: ", "))
             """,
-        version: "1.0.1"
+        version: "1.0.4"
     )
     
     

--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -40,7 +40,7 @@ struct ProjectGenerator {
             projectName: self.package.package.name,
             xcodeprojPath: path,
             graph: self.package.graph,
-            options: XcodeprojOptions(),
+            options: XcodeprojOptions(addExtraFiles: false),
             diagnostics: self.package.diagnostics
         )
     }


### PR DESCRIPTION
The top-level folders in the Swift package that contained no Swift code (eg. if you had a `Documentation` folder) were included in the generated Xcode project. These caused xcodebuild to throw an assertion failure on some packages:

```Details:  Error: Mismatch between existing container extension: <DVTExtension 0x7fbaa97b5c20: Folder (Xcode.IDEFoundation.Container.Folder) from com.apple.dt.IDEFoundation> and requested container extension: <DVTExtension 0x7fbaab1072c0: Swift User Managed Package Folder (Xcode.IDEFoundation.Container.SwiftPackageUserManagedFolder) from com.apple.dt.IDE.IDESwiftPackageSupport> for file path: <DVTFilePath:0x7fbab1247a80:'<project>/Documentation'>
```

We get around this by excluding these "extra files" at project generation time - they should have no affect on the build anyway.