### PR TITLE
Added checksum computation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "swift-5.2-branch",
-          "revision": "d6dd04202d509f91d61aef89236db0da8f27d356",
+          "branch": "master",
+          "revision": "145c113cde37318f3cef38843f9ce6a678aaa4fd",
           "version": null
         }
       },
@@ -23,8 +23,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "swift-5.2.3-RELEASE",
-          "revision": "b38b1cb61325a9d0e287d1ad9ffb5cfae38e7a22",
+          "branch": "release/5.3",
+          "revision": "f4cf6f773f046b0a769bab5fb2375d90463b3e9a",
           "version": null
         }
       },
@@ -32,8 +32,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "swift-5.2-branch",
-          "revision": "7ecf17a83eab20cbd700d7e45d66c03409bc72d0",
+          "branch": "master",
+          "revision": "81e2cda46447b4d78c18e03b0d284d76950f7c2b",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.0.6"),
-        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .revision("swift-5.2.3-RELEASE")),
+        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.3")),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.1.3"),
     ],
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ If the target you are creating an XCFramework happens to be a dependency, swift-
 
 If the target you are creating is a product from the root package, unfortunately there is no standard way to identify the version number. For those cases you can specify one with `--zip-version`.
 
+Because you're probably wanting to [distribute your binary frameworks as Swift Packages][apple-docs] `swift create-xcframework --zip` will also calculate the necessary SHA256 checksum and place it alongside the zip. eg: `ArgumentParser-0.0.6.sha256`.
+
 ## GitHub Action
 
 swift-create-xcframework includes a GitHub Action that can kick off and automatically create an XCFramework when you tag a release in your project.
 
-The action produces one XCFramework artifact for every target specified.
+The action produces one zipped XCFramework and checksum artifact for every target specified.
 
 **Note:** You MUST use a macOS-based runner (such as `macos-latest`) as xcodebuild doesn't run on Linux.
 
@@ -153,3 +155,5 @@ Please read the [Contribution Guide](CONTRIBUTING.md) for details on how to cont
 ## License
 
 swift-create-xcframework is available under the MIT license. See the [LICENSE](LICENSE) file for more info.
+
+[apple-docs]: https://developer.apple.com/documentation/swift_packages/distributing_binary_frameworks_as_swift_packages

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -106,11 +106,12 @@ struct Command: ParsableCommand {
         if self.options.zip {
             let zipper = Zipper(package: package)
             let zipped = try xcframeworkFiles
-                .map { pair -> Foundation.URL in
+                .flatMap { pair -> [Foundation.URL] in
                     let zip = try zipper.zip(target: pair.0, version: self.options.zipVersion, file: pair.1)
+                    let checksum = try zipper.checksum(file: zip)
                     try zipper.clean(file: pair.1)
 
-                    return zip
+                    return [ zip, checksum ]
                 }
 
             // notify the action if we have one

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -49,6 +49,13 @@ struct Zipper {
 
         return zipURL
     }
+
+    func checksum (file: Foundation.URL) throws -> Foundation.URL {
+        let sum = self.package.workspace.checksum(forBinaryArtifactAt: AbsolutePath(file.path), diagnostics: self.package.diagnostics)
+        let checksumFile = file.deletingPathExtension().appendingPathExtension("sha256")
+        try Data(sum.utf8).write(to: checksumFile)
+        return checksumFile
+    }
     
     private func zipCommand (source: Foundation.URL, target: Foundation.URL) -> [String] {
         return [

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -66,12 +66,8 @@ struct Zipper {
         // find the package that contains our target
         guard let packageRef = self.package.graph.packages.first(where: { $0.targets.contains(where: { $0.name == target } ) }) else { return nil }
 
-        // ok lets ask the workspace for that package's version
-        guard let resources = try? UserManifestResources(swiftCompiler: self.package.toolchain.swiftCompiler) else { return nil }
-        let workspace = Workspace.create(forRootPackage: AbsolutePath(self.package.rootDirectory.path), manifestLoader: ManifestLoader(manifestResources: resources))
-
         guard
-            let dependency = try? workspace.managedDependencies.dependency(forNameOrIdentity: packageRef.name),
+            let dependency = self.package.workspace.state.dependencies[forNameOrIdentity: packageRef.name],
             case let .checkout(checkout) = dependency.state,
             let version = checkout.version
         else {


### PR DESCRIPTION
This PR adds support for calculating the SHA256 checksum needed to use a framework in a Swift 5.3 Binary Target.

- We now track the [release/5.3](https://github.com/apple/swift-package-manager/tree/release/5.3) branch of SwiftPM
- The SHA256 checksum is calculated using the same code as `swift package compute-checksum`
- The checksum is calculated only when using `--zip`
- The checksum is placed alongside the zip file. eg: `MyFramework.zip` and `MyFramework.sha256`.
- This change supports both Xcode 11 (tested on 11.5 only) and Xcode 12
- Closes #8 