### PR TITLE
XCConfig Support

### DIFF
--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -30,6 +30,9 @@ extension Command {
         
         @Flag(help: "Prints the available products and targets")
         var listProducts: Bool
+
+        @Option(help: "The path to a .xcconfig file that can be used to override Xcode build settings. Relative to the package path.")
+        var xcconfig: String?
         
         
         // MARK: - Output Options

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -50,7 +50,7 @@ struct Command: ParsableCommand {
         let platforms = try package.supportedPlatforms()
 
         // get what we're building
-        try generator.writeXcconfig()
+        try generator.writeDistributionXcconfig()
         let project = try generator.generate()
 
         // printing packages?
@@ -65,9 +65,7 @@ struct Command: ParsableCommand {
 
         // we've applied the xcconfig to everything, but some dependencies (*cough* swift-nio)
         // have build errors, so we remove it from targets we're not building
-        for target in project.targets where productNames.contains(target.name) == false {
-            target.buildSettings.xcconfigFileRef = nil
-        }
+        try project.enableDistribution(targets: productNames, xcconfig: AbsolutePath(package.distributionBuildXcconfig.path).relative(to: AbsolutePath(package.rootDirectory.path)))
 
         // save the project
         try project.save(to: generator.projectPath)

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -32,7 +32,22 @@ struct PackageInfo {
             .appendingPathComponent("Distribution.xcconfig")
             .absoluteURL
     }
-    
+
+    var overridesXcconfig: Foundation.URL? {
+        guard let path = self.options.xcconfig else { return nil }
+
+        // absolute path
+        if path.hasPrefix("/") {
+            return Foundation.URL(fileURLWithPath: path)
+
+        // strip current directory if thats where we are
+        } else if path.hasPrefix("./") {
+            return self.rootDirectory.appendingPathComponent(String(path[path.index(path.startIndex, offsetBy: 2)...]))
+        }
+
+        return self.rootDirectory.appendingPathComponent(path)
+    }
+
     // TODO: Map diagnostics to swift-log
     let diagnostics = DiagnosticsEngine()
     

--- a/action.js
+++ b/action.js
@@ -15,6 +15,7 @@ async function run () {
         let targets = core.getInput('target', { required: false })
         let configuration = core.getInput('configuration', { required: false })
         let platforms = core.getInput('platforms', { required: false })
+        let xcconfig = core.getInput('xcconfig', { required: false })
 
         // install mint if its not installed
         await installUsingBrewIfRequired("mint")
@@ -32,6 +33,11 @@ async function run () {
         if (!!configuration) {
             options.push('--configuration')
             options.push(configuration)
+        }
+
+        if (!!xcconfig) {
+            options.push('--xcconfig')
+            options.push(xcconfig)
         }
 
         if (!!platforms) {

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: "Build with a specific configuration ('debug' or 'release')"
     required: false
     default: release
+  xcconfig:
+    description: "The path to a .xcconfig file that can be used to override Xcode build settings. Relative to the package path."
+    required: false
 
 runs:
   using: node12


### PR DESCRIPTION
Added support for supplying an `--xcconfig` option (and equivalent GitHub Action parameter).

It can be used to provide a path to a .xcconfig file with build settings you'd like to apply to the generated project. In effect it uses `swift package generate-xcodeproj --xcconfig-overrides`.

Closes #12 