### PR TITLE
Added support for Catalyst

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           path: Vexil
 
       - name: 📦 Package Vexil
-        run: cd Vexil && ../.build/release/swift-create-xcframework --zip --zip-version 1.2.2 --platform ios --platform macos --platform tvos --platform watchos Vexil Vexillographer
+        run: cd Vexil && ../.build/release/swift-create-xcframework --zip --zip-version 1.2.2 --platform ios --platform macos --platform tvos --platform watchos
 
   tests-xcode-12:
     name: Test Builds - Xcode 12
@@ -57,4 +57,4 @@ jobs:
           path: Vexil
 
       - name: 📦 Package Vexil
-        run: cd Vexil && ../.build/release/swift-create-xcframework --zip --zip-version 1.2.2 --platform ios --platform macos --platform tvos --platform watchos Vexil Vexillographer
+        run: cd Vexil && ../.build/release/swift-create-xcframework --zip --zip-version 1.2.2 --platform ios --platform macos --platform tvos --platform watchos

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ You can specify a subset of the platforms to build using the `--platform` option
 swift create-xcframework --platform ios --platform macos ...
 ```
 
+#### Catalyst
+
+You can build your XCFrameworks with support for Mac Catalyst by specifying `--platform maccatalyst` on the command line. As you can't include or exclude Catalyst support in your `Package.swift` we don't try to build it automatically.
+
 ### Choosing Products
 
 Because we wrap `xcodebuild`, you can actually build XCFrameworks from anything that will be mapped to an Xcode project as a Framework target. This includes all of the dependencies your Package has.
@@ -126,7 +130,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Create XCFramework
-        uses: unsignedapps/swift-create-xcframework@v1
+        uses: unsignedapps/swift-create-xcframework@v1.3
 
       # Create a release
       # Upload those artifacts to the release
@@ -137,7 +141,7 @@ jobs:
 You can install using mint:
 
 ```shell
-mint install unsignedapps/swift-create-xcframework@1.0.5
+mint install unsignedapps/swift-create-xcframework@1.3.0
 ```
 
 Or manually:

--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -44,7 +44,7 @@ extension Command {
                 valueName: TargetPlatform.allCases.map({ $0.rawValue }).joined(separator: "|")
             )
         )
-        var platform: [TargetPlatform]
+        var platform: [TargetPlatform] = []
 
         @Option(help: ArgumentHelp("Where to place the compiled .xcframework(s)", valueName: "directory"))
         var output = "."
@@ -69,7 +69,7 @@ extension Command {
         // MARK: - Targets
 
         @Argument(help: "An optional list of products (or targets) to build. Defaults to building all `.library` products")
-        var products: [String]
+        var products: [String] = []
     }
 }
 

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -27,7 +27,7 @@ struct Command: ParsableCommand {
 
             Supported platforms: \(TargetPlatform.allCases.map({ $0.rawValue }).joined(separator: ", "))
             """,
-        version: "1.2.1"
+        version: "1.3.0"
     )
 
 

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -160,7 +160,8 @@ struct PackageInfo {
     /// check if our command line platforms are supported by the package definition
     func supportedPlatforms () throws -> [TargetPlatform] {
 
-        let supported = self.options.platform.nonEmpty ?? TargetPlatform.allCases
+        // if they have specified platforms all good, if not go everything except catalyst
+        let supported = self.options.platform.nonEmpty ?? TargetPlatform.allCases.filter { $0 != .maccatalyst }
 
         // do we have package platforms defined?
         guard let packagePlatforms = self.manifest.platforms.nonEmpty else {
@@ -169,11 +170,11 @@ struct PackageInfo {
 
         // filter our package platforms to make sure everything is supported
         let target = packagePlatforms
-            .compactMap { platform -> TargetPlatform? in
-                return supported.first(where: { $0.rawValue == platform.platformName })
+            .compactMap { platform -> [TargetPlatform]? in
+                return supported.filter({ $0.platformName == platform.platformName })
             }
+            .flatMap { $0 }
 
-        // are they different then?
         return target
     }
 

--- a/Sources/CreateXCFramework/Platforms.swift
+++ b/Sources/CreateXCFramework/Platforms.swift
@@ -11,6 +11,7 @@ import PackageModel
 enum TargetPlatform: String, ExpressibleByArgument, CaseIterable {
     case ios
     case macos
+    case maccatalyst
     case tvos
     case watchos
 
@@ -19,36 +20,52 @@ enum TargetPlatform: String, ExpressibleByArgument, CaseIterable {
     }
 
 
+    var platformName: String {
+        switch self {
+        case .ios:          return "ios"
+        case .macos:        return "macos"
+        case .maccatalyst:  return "macos"
+        case .tvos:         return "tvos"
+        case .watchos:      return "watchos"
+        }
+    }
+
     // MARK: - Target SDKs
 
     struct SDK {
-        let sdkName: String
-        let directorySuffix: String
+        let destination: String
+        let archiveName: String
+        let buildSettings: [String: String]?
     }
 
     var sdks: [SDK] {
         switch self {
         case .ios:
             return [
-                SDK(sdkName: "iphoneos", directorySuffix: "-iphoneos"),
-                SDK(sdkName: "iphonesimulator", directorySuffix: "-iphonesimulator")
+                SDK(destination: "generic/platform=iOS", archiveName: "iphoneos.xcarchive", buildSettings: nil),
+                SDK(destination: "generic/platform=iOS Simulator", archiveName: "iphonesimulator.xcarchive", buildSettings: nil)
             ]
 
         case .macos:
             return [
-                SDK(sdkName: "macosx", directorySuffix: "")
+                SDK(destination: "platform=macOS", archiveName: "macos.xcarchive", buildSettings: nil)
+            ]
+
+        case .maccatalyst:
+            return [
+                SDK(destination: "platform=macOS,variant=Mac Catalyst", archiveName: "maccatalyst.xcarchive", buildSettings: [ "SUPPORTS_MACCATALYST": "YES" ])
             ]
 
         case .tvos:
             return [
-                SDK(sdkName: "appletvos", directorySuffix: "-appletvos"),
-                SDK(sdkName: "appletvsimulator", directorySuffix: "-appletvsimulator")
+                SDK(destination: "generic/platform=tvOS", archiveName: "appletvos.xcarchive", buildSettings: nil),
+                SDK(destination: "generic/platform=tvOS Simulator", archiveName: "appletvsimulator.xcarchive", buildSettings: nil)
             ]
 
         case .watchos:
             return [
-                SDK(sdkName: "watchos", directorySuffix: "-watchos"),
-                SDK(sdkName: "watchsimulator", directorySuffix: "-watchsimulator")
+                SDK(destination: "generic/platform=watchOS", archiveName: "watchos.xcarchive", buildSettings: nil),
+                SDK(destination: "generic/platform=watchOS Simulator", archiveName: "watchsimulator.xcarchive", buildSettings: nil)
             ]
         }
     }

--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -73,7 +73,10 @@ struct ProjectGenerator {
             graph: self.package.graph,
             extraDirs: [],
             extraFiles: [],
-            options: XcodeprojOptions(xcconfigOverrides: (self.package.overridesXcconfig?.path).flatMap { AbsolutePath($0) }),
+            options: XcodeprojOptions (
+                xcconfigOverrides: (self.package.overridesXcconfig?.path).flatMap { AbsolutePath($0) },
+                useLegacySchemeGenerator: true
+            ),
             diagnostics: self.package.diagnostics
         )
 


### PR DESCRIPTION
Adds support for the `--maccatalyst` platform. Because its not a platform you can specify in the `Package.swift` file we won't build it automatically, but you can specify it on the command line as required.

This switches to using the legacy project generator and archiving (as opposed to just building) so its a lot more reliable, but unfortunately some builds will take longer.