### PR TITLE
Include debugging symbols in the merged XCFrameworks

### DIFF
--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -28,6 +28,9 @@ extension Command {
         @Flag(inversion: .prefixedNo, help: "Whether to clean before we build")
         var clean = true
 
+        @Flag(inversion: .prefixedNo, help: "Whether to include debug symbols in the built XCFramework")
+        var debugSymbols = true
+
         @Flag(help: "Prints the available products and targets")
         var listProducts = false
 

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -80,7 +80,7 @@ struct Command: ParsableCommand {
         }
 
         // all of our targets for each platform, then group the resulting .frameworks by target
-        var frameworkFiles: [String: [Foundation.URL]] = [:]
+        var frameworkFiles: [String: [XcodeBuilder.BuildResult]] = [:]
 
         for sdk in sdks {
             try builder.build(targets: productNames, sdk: sdk)
@@ -97,7 +97,7 @@ struct Command: ParsableCommand {
         // then we merge the resulting frameworks
         try frameworkFiles
             .forEach { pair in
-                xcframeworkFiles.append((pair.key, try builder.merge(target: pair.key, frameworks: pair.value)))
+                xcframeworkFiles.append((pair.key, try builder.merge(target: pair.key, buildResults: pair.value)))
             }
 
         // zip it up if thats what they want

--- a/Sources/CreateXCFramework/Platforms.swift
+++ b/Sources/CreateXCFramework/Platforms.swift
@@ -35,6 +35,7 @@ enum TargetPlatform: String, ExpressibleByArgument, CaseIterable {
     struct SDK {
         let destination: String
         let archiveName: String
+        let releaseFolder: String
         let buildSettings: [String: String]?
     }
 
@@ -42,30 +43,70 @@ enum TargetPlatform: String, ExpressibleByArgument, CaseIterable {
         switch self {
         case .ios:
             return [
-                SDK(destination: "generic/platform=iOS", archiveName: "iphoneos.xcarchive", buildSettings: nil),
-                SDK(destination: "generic/platform=iOS Simulator", archiveName: "iphonesimulator.xcarchive", buildSettings: nil)
+                SDK (
+                    destination: "generic/platform=iOS",
+                    archiveName: "iphoneos.xcarchive",
+                    releaseFolder: "Release-iphoneos",
+                    buildSettings: nil
+                ),
+                SDK (
+                    destination: "generic/platform=iOS Simulator",
+                    archiveName: "iphonesimulator.xcarchive",
+                    releaseFolder: "Release-iphonesimulator",
+                    buildSettings: nil
+                )
             ]
 
         case .macos:
             return [
-                SDK(destination: "platform=macOS", archiveName: "macos.xcarchive", buildSettings: nil)
+                SDK (
+                    destination: "platform=macOS",
+                    archiveName: "macos.xcarchive",
+                    releaseFolder: "Release",
+                    buildSettings: nil
+                )
             ]
 
         case .maccatalyst:
             return [
-                SDK(destination: "platform=macOS,variant=Mac Catalyst", archiveName: "maccatalyst.xcarchive", buildSettings: [ "SUPPORTS_MACCATALYST": "YES" ])
+                SDK (
+                    destination: "platform=macOS,variant=Mac Catalyst",
+                    archiveName: "maccatalyst.xcarchive",
+                    releaseFolder: "Release-maccatalyst",
+                    buildSettings: [ "SUPPORTS_MACCATALYST": "YES" ]
+                )
             ]
 
         case .tvos:
             return [
-                SDK(destination: "generic/platform=tvOS", archiveName: "appletvos.xcarchive", buildSettings: nil),
-                SDK(destination: "generic/platform=tvOS Simulator", archiveName: "appletvsimulator.xcarchive", buildSettings: nil)
+                SDK (
+                    destination: "generic/platform=tvOS",
+                    archiveName: "appletvos.xcarchive",
+                    releaseFolder: "Release-appletvos",
+                    buildSettings: nil
+                ),
+                SDK (
+                    destination: "generic/platform=tvOS Simulator",
+                    archiveName: "appletvsimulator.xcarchive",
+                    releaseFolder: "Release-appletvsimulator",
+                    buildSettings: nil
+                )
             ]
 
         case .watchos:
             return [
-                SDK(destination: "generic/platform=watchOS", archiveName: "watchos.xcarchive", buildSettings: nil),
-                SDK(destination: "generic/platform=watchOS Simulator", archiveName: "watchsimulator.xcarchive", buildSettings: nil)
+                SDK (
+                    destination: "generic/platform=watchOS",
+                    archiveName: "watchos.xcarchive",
+                    releaseFolder: "Release-watchos",
+                    buildSettings: nil
+                ),
+                SDK (
+                    destination: "generic/platform=watchOS Simulator",
+                    archiveName: "watchsimulator.xcarchive",
+                    releaseFolder: "Release-watchsimulator",
+                    buildSettings: nil
+                )
             ]
         }
     }

--- a/Sources/CreateXCFramework/XcodeBuilder.swift
+++ b/Sources/CreateXCFramework/XcodeBuilder.swift
@@ -57,17 +57,23 @@ struct XcodeBuilder {
         switch result.exitStatus {
         case let .terminated(code: code):
             if code != 0 {
-                throw Error.nonZeroExit(code)
+                throw Error.nonZeroExit("xcodebuild", code)
             }
         case let .signalled(signal: signal):
-            throw Error.signalExit(signal)
+            throw Error.signalExit("xcodebuild", signal)
         }
     }
 
 
     // MARK: - Build
 
-    func build (targets: [String], sdk: TargetPlatform.SDK) throws -> [String: Foundation.URL] {
+    struct BuildResult {
+        let target: String
+        let frameworkPath: Foundation.URL
+        let debugSymbolsPath: Foundation.URL
+    }
+
+    func build (targets: [String], sdk: TargetPlatform.SDK) throws -> [String: BuildResult] {
         for target in targets {
             let process = TSCBasic.Process (
                 arguments: try self.buildCommand(target: target, sdk: sdk),
@@ -80,16 +86,20 @@ struct XcodeBuilder {
             switch result.exitStatus {
             case let .terminated(code: code):
                 if code != 0 {
-                    throw Error.nonZeroExit(code)
+                    throw Error.nonZeroExit("xcodebuild", code)
                 }
             case let .signalled(signal: signal):
-                throw Error.signalExit(signal)
+                throw Error.signalExit("xcodebuild", signal)
             }
         }
 
         return targets
-            .reduce(into: [String: Foundation.URL]()) { dict, name in
-                dict[name] = self.frameworkPath(target: name, sdk: sdk)
+            .reduce(into: [String: BuildResult]()) { dict, name in
+                dict[name] = BuildResult (
+                    target: name,
+                    frameworkPath: self.frameworkPath(target: name, sdk: sdk),
+                    debugSymbolsPath: self.debugSymbolsPath(target: name, sdk: sdk)
+                )
             }
     }
 
@@ -131,17 +141,103 @@ struct XcodeBuilder {
             .absoluteURL
     }
 
+    // MARK: - Debug Symbols
+
+    private func debugSymbolsPath (target: String, sdk: TargetPlatform.SDK) -> Foundation.URL {
+        return self.buildDirectory
+            .appendingPathComponent(sdk.releaseFolder)
+    }
+
+    private func dSYMPath (target: String, path: Foundation.URL) -> Foundation.URL {
+        return path
+            .appendingPathComponent("\(self.productName(target: target)).framework.dSYM")
+    }
+
+    private func dwarfPath (target: String, path: Foundation.URL) -> Foundation.URL {
+        return path
+            .appendingPathComponent("Contents/Resources/DWARF")
+            .appendingPathComponent(self.productName(target: target))
+    }
+
+    private func debugSymbolFiles (target: String, path: Foundation.URL) throws -> [Foundation.URL] {
+
+        // if there is no dSYM directory there is no point continuing
+        let dsym = self.dSYMPath(target: target, path: path)
+        guard FileManager.default.fileExists(atPath: dsym.absoluteURL.path) else {
+            return []
+        }
+
+        var files = [
+            dsym
+        ]
+
+        // if we have a dwarf file we can inspect that to get the slice UUIDs
+        let dwarf = self.dwarfPath(target: target, path: dsym)
+        guard FileManager.default.fileExists(atPath: dwarf.absoluteURL.path) else {
+            return files
+        }
+
+        // get the UUID of the slices in the DWARF
+        let identifiers = try self.binarySliceIdentifiers(file: dwarf)
+
+        // They should be bcsymbolmap files in the debug dir
+        for identifier in identifiers {
+            let file = "\(identifier.uuidString.uppercased()).bcsymbolmap"
+            files.append(path.appendingPathComponent(file))
+        }
+
+        return files
+    }
+
+    private func binarySliceIdentifiers (file: Foundation.URL) throws -> [UUID] {
+        let command = [
+            "xcrun",
+            "dwarfdump",
+            "--uuid",
+            file.absoluteURL.path
+        ]
+
+        let process = TSCBasic.Process (
+            arguments: command,
+            outputRedirection: .collect
+        )
+
+        try process.launch()
+        let result = try process.waitUntilExit()
+
+        switch result.exitStatus {
+        case let .terminated(code: code):
+            if code != 0 {
+                throw Error.nonZeroExit("dwarfdump", code)
+            }
+
+        case let .signalled(signal: signal):
+            throw Error.signalExit("dwarfdump", signal)
+        }
+
+        switch result.output {
+        case let .success(output):
+            guard let string = String(bytes: output, encoding: .utf8) else {
+                return []
+            }
+            return try string.sliceIdentifiers()
+
+        case let .failure(error):
+            throw Error.errorThrown("dwarfdump", error)
+        }
+    }
+
 
     // MARK: - Merging
 
-    func merge (target: String, frameworks: [Foundation.URL]) throws -> Foundation.URL {
+    func merge (target: String, buildResults: [BuildResult]) throws -> Foundation.URL {
         let outputPath = self.xcframeworkPath(target: target)
 
         // try to remove it if its already there, otherwise we're going to get errors
         try? FileManager.default.removeItem(at: outputPath)
 
         let process = TSCBasic.Process (
-            arguments: self.mergeCommand(outputPath: outputPath, frameworks: frameworks),
+            arguments: try self.mergeCommand(outputPath: outputPath, buildResults: buildResults),
             outputRedirection: .none
         )
 
@@ -151,27 +247,42 @@ struct XcodeBuilder {
         switch result.exitStatus {
         case let .terminated(code: code):
             if code != 0 {
-                throw Error.nonZeroExit(code)
+                throw Error.nonZeroExit("xcodebuild", code)
             }
         case let .signalled(signal: signal):
-            throw Error.signalExit(signal)
+            throw Error.signalExit("xcodebuild", signal)
         }
 
         return outputPath
     }
 
-    private func mergeCommand (outputPath: Foundation.URL, frameworks: [Foundation.URL]) -> [String] {
+    private func mergeCommand (outputPath: Foundation.URL, buildResults: [BuildResult]) throws -> [String] {
         var command: [String] = [
             "xcrun",
             "xcodebuild",
             "-create-xcframework"
         ]
 
-        // add our frameworks
-        command += frameworks.flatMap { [ "-framework", $0.path ] }
+        // add our frameworks and any debugging symbols
+        command += try buildResults.flatMap { result -> [String] in
+            var args = [ "-framework", result.frameworkPath.absoluteURL.path ]
+
+            if self.package.options.debugSymbols {
+                let symbolFiles = try self.debugSymbolFiles(target: result.target, path: result.debugSymbolsPath)
+                for file in symbolFiles {
+                    if FileManager.default.fileExists(atPath: file.absoluteURL.path) {
+                        args += [ "-debug-symbols", file.absoluteURL.path ]
+                    }
+                }
+
+            }
+
+            return args
+        }
 
         // and the output
         command += [ "-output", outputPath.path ]
+
         return command
     }
 
@@ -193,15 +304,18 @@ struct XcodeBuilder {
     // MARK: - Errors
 
     enum Error: Swift.Error, LocalizedError {
-        case nonZeroExit(Int32)
-        case signalExit(Int32)
+        case nonZeroExit(String, Int32)
+        case signalExit(String, Int32)
+        case errorThrown(String, Swift.Error)
 
         var errorDescription: String? {
             switch self {
-            case let .nonZeroExit(code):
-                return "xcodebuild exited with a non-zero code: \(code)"
-            case let .signalExit(signal):
-                return "xcodebuild exited due to signal: \(signal)"
+            case let .nonZeroExit(command, code):
+                return "\(command) exited with a non-zero code: \(code)"
+            case let .signalExit(command, signal):
+                return "\(command) exited due to signal: \(signal)"
+            case let .errorThrown(command, error):
+                return "\(command) returned unexpected error: \(error)"
             }
         }
     }
@@ -216,5 +330,26 @@ extension BuildConfiguration {
         case .debug:        return "Debug"
         case .release:      return "Release"
         }
+    }
+}
+
+private extension String {
+    func sliceIdentifiers() throws -> [UUID] {
+        let regex = try NSRegularExpression(pattern: #"^UUID: ([a-zA-Z0-9\-]+)"#, options: .anchorsMatchLines)
+        let matches = regex.matches(in: self, options: [], range: NSRange(location: 0, length: self.count))
+
+        guard matches.isEmpty == false else {
+            return []
+        }
+
+        return matches
+            .compactMap { match in
+                let nsrange = match.range(at: 1)
+                guard let range = Range(nsrange, in: self) else {
+                    return nil
+                }
+                return String(self[range])
+            }
+            .compactMap(UUID.init(uuidString:))
     }
 }

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -41,10 +41,10 @@ struct Zipper {
         switch result.exitStatus {
         case let .terminated(code: code):
             if code != 0 {
-                throw XcodeBuilder.Error.nonZeroExit(code)
+                throw XcodeBuilder.Error.nonZeroExit("ditto", code)
             }
         case let .signalled(signal: signal):
-            throw XcodeBuilder.Error.signalExit(signal)
+            throw XcodeBuilder.Error.signalExit("ditto", signal)
         }
 
         return zipURL


### PR DESCRIPTION
This PR adds initial support for including debugging symbols (specifically dSYM and BCSymbolMap files) in the produced XCFrameworks.

You can control the inclusion of debugging symbols using the `--debug-symbols` and `--no-debug-symbols` options. The default is to **include** debugging symbols.

This resolves #19.