### PR TITLE
Change mint tag to match naming convetion

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ jobs:
 You can install using mint:
 
 ```shell
-mint install unsignedapps/swift-create-xcframework@1.3.0
+mint install unsignedapps/swift-create-xcframework@v1.3.0
 ```
 
 Or manually:


### PR DESCRIPTION
The `mint` command tag was not valid as the tags are prefixed with `v`