### PR TITLE
Add validation against unsupported package targets (binary targets, system modules, conditional dependencies)

### DIFF
--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -44,6 +44,17 @@ struct Command: ParsableCommand {
         // load all/validate of the package info
         let package = try PackageInfo(options: self.options)
 
+        // validate that package to make sure we can generate it
+        let validation = package.validationErrors()
+        if validation.isEmpty == false {
+            for error in validation {
+                print((error.isFatal ? "Error:" : "Warning:"), error.errorDescription!)
+            }
+            if validation.contains(where: { $0.isFatal }) {
+                Darwin.exit(1)
+            }
+        }
+
         // generate the Xcode project file
         let generator = ProjectGenerator(package: package)
 
@@ -69,7 +80,6 @@ struct Command: ParsableCommand {
 
         // save the project
         try project.save(to: generator.projectPath)
-
 
         // start building
         let builder = XcodeBuilder(project: project, projectPath: generator.projectPath, package: package, options: self.options)

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -39,6 +39,7 @@ struct Command: ParsableCommand {
 
     // MARK: - Execution
 
+    // swiftlint:disable:next function_body_length
     func run() throws {
 
         // load all/validate of the package info

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -52,14 +52,14 @@ struct PackageInfo {
     let diagnostics = DiagnosticsEngine()
 
     let options: Command.Options
-    let package: Package
+//    let package: Package
     let graph: PackageGraph
     let manifest: Manifest
     let toolchain: Toolchain
     let workspace: Workspace
 
 
-    // MARJ: - Initialisation
+    // MARK: - Initialisation
 
     init (options: Command.Options) throws {
         self.options = options
@@ -74,13 +74,6 @@ struct PackageInfo {
         let loader = ManifestLoader(manifestResources: resources)
         self.workspace = Workspace.create(forRootPackage: root, manifestLoader: loader)
 
-        self.package = try PackageBuilder.loadPackage (
-            packagePath: root,
-            swiftCompiler: self.toolchain.swiftCompiler,
-            xcTestMinimumDeploymentTargets: [:],
-            diagnostics: self.diagnostics
-        )
-
         self.graph = self.workspace.loadPackageGraph(root: root, diagnostics: self.diagnostics)
 
         self.manifest = try ManifestLoader.loadManifest (
@@ -88,6 +81,33 @@ struct PackageInfo {
             swiftCompiler: self.toolchain.swiftCompiler,
             packageKind: .root
         )
+    }
+
+
+    // MARK: - Validation
+
+    func validationErrors () -> [PackageValidationError] {
+        var errors = [PackageValidationError]()
+
+        // check the graph for binary targets
+        let binary = self.graph.allTargets.filter { $0.type == .binary }
+        if binary.isEmpty == false {
+            errors.append(.containsBinaryTargets(binary.map(\.name)))
+        }
+
+        // check for system modules
+        let system = self.graph.allTargets.filter { $0.type == .systemModule }
+        if system.isEmpty == false {
+            errors.append(.containsSystemModules(system.map(\.name)))
+        }
+
+        // and for conditional dependencies
+        let conditionals = self.graph.allTargets.filter { $0.dependencies.contains { $0.conditions.isEmpty == false } }
+        if conditionals.isEmpty == false {
+            errors.append(.containsConditionalDependencies(conditionals.map(\.name)))
+        }
+
+        return errors
     }
 
 
@@ -100,7 +120,7 @@ struct PackageInfo {
         if self.options.products.isEmpty == false {
             productNames = self.options.products
         } else {
-            productNames = package.manifest.libraryProductNames
+            productNames = self.manifest.libraryProductNames
         }
 
         // validation
@@ -115,7 +135,7 @@ struct PackageInfo {
         let invalidProducts = productNames.filter { xcodeTargetNames.contains($0) == false }
         guard invalidProducts.isEmpty == true else {
 
-            let allLibraryProductNames = self.package.manifest.libraryProductNames
+            let allLibraryProductNames = self.manifest.libraryProductNames
             let nonRootPackageTargets = xcodeTargetNames.filter { allLibraryProductNames.contains($0) == false }
 
             throw ValidationError (
@@ -123,7 +143,7 @@ struct PackageInfo {
                 Invalid product/target name(s):
                     \(invalidProducts.joined(separator: "\n    "))
 
-                Available \(self.package.name) products:
+                Available \(self.manifest.name) products:
                     \(allLibraryProductNames.sorted().joined(separator: "\n    "))
 
                 Additional available targets:
@@ -136,13 +156,13 @@ struct PackageInfo {
     }
 
     func printAllProducts (project: Xcode.Project) {
-        let allLibraryProductNames = self.package.manifest.libraryProductNames
+        let allLibraryProductNames = self.manifest.libraryProductNames
         let xcodeTargetNames = project.frameworkTargets.map { $0.name }
         let nonRootPackageTargets = xcodeTargetNames.filter { allLibraryProductNames.contains($0) == false }
 
         print (
             """
-            \nAvailable \(self.package.name) products:
+            \nAvailable \(self.manifest.name) products:
                 \(allLibraryProductNames.sorted().joined(separator: "\n    "))
 
             Additional available targets:
@@ -182,6 +202,7 @@ struct PackageInfo {
     private var absoluteRootDirectory: AbsolutePath {
         AbsolutePath(self.rootDirectory.path)
     }
+
 }
 
 
@@ -206,3 +227,32 @@ extension SupportedPlatform: Equatable, Comparable {
         return lhs.platform.name < rhs.platform.name
     }
 }
+
+// MARK: - Validation Errors
+
+enum PackageValidationError: LocalizedError {
+    case containsBinaryTargets([String])
+    case containsSystemModules([String])
+    case containsConditionalDependencies([String])
+
+    var isFatal: Bool {
+        switch self {
+        case .containsBinaryTargets, .containsSystemModules:
+            return true
+        case .containsConditionalDependencies:
+            return false
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case let .containsBinaryTargets(targets):
+            return "Xcode project generation is not supported by Swift Package Manager for packages that contain binary targets. These binary targets were detected: \(targets.joined(separator: ", "))"
+        case let .containsSystemModules(targets):
+            return "Xcode project generation is not supported by Swift Package Manager for packages that reference system modules. These system modules were referenced: \(targets.joined(separator: ", "))"
+        case let .containsConditionalDependencies(targets):
+            return "Xcode project generation does not support conditional target dependencies, so the generated project may not build successfully. These targets contain conditional dependencies: \(targets.joined(separator: ", "))"
+        }
+    }
+}
+

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -247,12 +247,14 @@ enum PackageValidationError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case let .containsBinaryTargets(targets):
-            return "Xcode project generation is not supported by Swift Package Manager for packages that contain binary targets. These binary targets were detected: \(targets.joined(separator: ", "))"
+            return "Xcode project generation is not supported by Swift Package Manager for packages that contain binary targets."
+                + "These binary targets were detected: \(targets.joined(separator: ", "))"
         case let .containsSystemModules(targets):
-            return "Xcode project generation is not supported by Swift Package Manager for packages that reference system modules. These system modules were referenced: \(targets.joined(separator: ", "))"
+            return "Xcode project generation is not supported by Swift Package Manager for packages that reference system modules."
+                + "These system modules were referenced: \(targets.joined(separator: ", "))"
         case let .containsConditionalDependencies(targets):
-            return "Xcode project generation does not support conditional target dependencies, so the generated project may not build successfully. These targets contain conditional dependencies: \(targets.joined(separator: ", "))"
+            return "Xcode project generation does not support conditional target dependencies, so the generated project may not build successfully."
+                + "These targets contain conditional dependencies: \(targets.joined(separator: ", "))"
         }
     }
 }
-

--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -23,7 +23,7 @@ struct ProjectGenerator {
 
     var projectPath: AbsolutePath {
         let dir = AbsolutePath(self.package.projectBuildDirectory.path)
-        return buildXcodeprojPath(outputDir: dir, projectName: self.package.package.name)
+        return buildXcodeprojPath(outputDir: dir, projectName: self.package.manifest.name)
     }
 
 


### PR DESCRIPTION
Swift Package Manager cannot generate Xcode Project files for packages that use `.binaryTarget()` or `.systemLibrary()`, and throw warnings when using conditional dependencies.

Instead of attempting to parse them and hitting a [fatalError with no error message](https://github.com/apple/swift-package-manager/blob/swift-5.3.3-RELEASE/Sources/Xcodeproj/pbxproj.swift#L400), we now check for the presence of targets that can't be generated and exit with a more informative error message.