### PR TITLE
Fix #27 Catalyst support

### DIFF
--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -56,6 +56,14 @@ struct ProjectGenerator {
                 BUILD_LIBRARY_FOR_DISTRIBUTION=YES
                 """
             )
+
+            if package.options.platform.contains(.maccatalyst) {
+                stream (
+                    """
+                    SUPPORTS_MACCATALYST=YES
+                    """
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/unsignedapps/swift-create-xcframework/issues/27

**RCA**

The .xcproject file generated for Catalyst didn't have `SUPPORTS_MACCATALYST` build setting set to true.
