### PR TITLE
Update swift-create-package version reference for the GH action

### DIFF
--- a/action.js
+++ b/action.js
@@ -4,7 +4,7 @@ const path = require('path')
 const artifact = require('././.action/artifact')
 const fs = require('fs')
 
-const scxVersion = '1.4.1'
+const scxVersion = '1.4.0'
 const outputPath = '.build/xcframework-zipfile.url'
 
 core.setCommandEcho(true)
@@ -94,7 +94,7 @@ async function installUsingMintIfRequired (command, package) {
 
     } else {
         core.info("Installing " + package)
-        await exec.exec('mint', [ 'install', 'mz2/swift-create-xcframework@' + scxVersion ])
+        await exec.exec('mint', [ 'install', 'unsignedapps/swift-create-xcframework@' + scxVersion ])
     }
 }
 

--- a/action.js
+++ b/action.js
@@ -4,7 +4,7 @@ const path = require('path')
 const artifact = require('././.action/artifact')
 const fs = require('fs')
 
-const scxVersion = '1.0.5'
+const scxVersion = '1.4.1'
 const outputPath = '.build/xcframework-zipfile.url'
 
 core.setCommandEcho(true)
@@ -94,7 +94,7 @@ async function installUsingMintIfRequired (command, package) {
 
     } else {
         core.info("Installing " + package)
-        await exec.exec('mint', [ 'install', 'unsignedapps/swift-create-xcframework@' + scxVersion ])
+        await exec.exec('mint', [ 'install', 'mz2/swift-create-xcframework@' + scxVersion ])
     }
 }
 


### PR DESCRIPTION
Updates swift-create-package version reference in action.js for the GH action.

I was experiencing build issues such as https://github.com/mz2/Carpaccio/runs/3514769905?check_suite_focus=true when the GH action uses the version 1.0.5, that [went away](https://github.com/mz2/Carpaccio/actions/runs/1201645439) when using a version of the GH action with 1.4.0 being built by mint.