### PR TITLE
Updated supported Xcode versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tests-xcode-12_5:
-    name: Test Builds - Xcode 12.5 (Beta)
+    name: Test Builds - Xcode 12.5
     runs-on: macos-11.0
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer


### PR DESCRIPTION
This PR:

- Updated workflows for Xcode 12.3 and Xcode 12.4 to run on macOS 10.15 as they are no longer supported on macOS 11
- Updated to test against Xcode 12.5.1 as support for Xcode 12.5 will be removed next week