### PR TITLE
Fixes Mac Catalyst support by using generic destinations properly

### DIFF
--- a/Sources/CreateXCFramework/Platforms.swift
+++ b/Sources/CreateXCFramework/Platforms.swift
@@ -60,7 +60,7 @@ enum TargetPlatform: String, ExpressibleByArgument, CaseIterable {
         case .macos:
             return [
                 SDK (
-                    destination: "platform=macOS",
+                    destination: "generic/platform=macOS,name=Any Mac",
                     archiveName: "macos.xcarchive",
                     releaseFolder: "Release",
                     buildSettings: nil
@@ -70,7 +70,7 @@ enum TargetPlatform: String, ExpressibleByArgument, CaseIterable {
         case .maccatalyst:
             return [
                 SDK (
-                    destination: "platform=macOS,variant=Mac Catalyst",
+                    destination: "generic/platform=macOS,variant=Mac Catalyst",
                     archiveName: "maccatalyst.xcarchive",
                     releaseFolder: "Release-maccatalyst",
                     buildSettings: [ "SUPPORTS_MACCATALYST": "YES" ]


### PR DESCRIPTION
Previously we were using `platform=macOS` and `platform=macOS,variant=Mac Catalyst` to distinguish between our macOS and Catalyst destinations, which was causing an issue with selecting the most appropriate destination with Xcode 13.

This PR fixes that by using generic destinations properly, eg `generic/platform=macOS,name=Any Mac` and `generic/platform=macOS,variant=Mac Catalyst` respectively.