### PR TITLE
Added the `--stack-evolution` option

### DIFF
--- a/Sources/CreateXCFramework/Command+Options.swift
+++ b/Sources/CreateXCFramework/Command+Options.swift
@@ -37,6 +37,9 @@ extension Command {
         @Option(help: "The path to a .xcconfig file that can be used to override Xcode build settings. Relative to the package path.")
         var xcconfig: String?
 
+        @Flag(help: "Enables Library Evolution for the whole build stack. Normally we apply it only to the targets listed to be built to work around issues with projects that don't support it.")
+        var stackEvolution: Bool = false
+
         @Option(help: ArgumentHelp("Arbitrary Xcode build settings that are passed directly to the `xcodebuild` invocation. Can be specified multiple times.", valueName: "NAME=VALUE"))
         var xcSetting: [BuildSetting] = []
 

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -77,7 +77,9 @@ struct Command: ParsableCommand {
 
         // we've applied the xcconfig to everything, but some dependencies (*cough* swift-nio)
         // have build errors, so we remove it from targets we're not building
-        try project.enableDistribution(targets: productNames, xcconfig: AbsolutePath(package.distributionBuildXcconfig.path).relative(to: AbsolutePath(package.rootDirectory.path)))
+        if self.options.stackEvolution == false {
+            try project.enableDistribution(targets: productNames, xcconfig: AbsolutePath(package.distributionBuildXcconfig.path).relative(to: AbsolutePath(package.rootDirectory.path)))
+        }
 
         // save the project
         try project.save(to: generator.projectPath)

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -27,6 +27,10 @@ struct PackageInfo {
             .absoluteURL
     }
 
+    var hasDistributionBuildXcconfig: Bool {
+        self.overridesXcconfig != nil || self.options.stackEvolution == false
+    }
+
     var distributionBuildXcconfig: Foundation.URL {
         return self.projectBuildDirectory
             .appendingPathComponent("Distribution.xcconfig")
@@ -232,7 +236,7 @@ enum SupportedPlatforms {
     case packageValid (plan: [SupportedPlatform])
 }
 
-extension SupportedPlatform: Equatable, Comparable {
+extension SupportedPlatform: Comparable {
     public static func == (lhs: SupportedPlatform, rhs: SupportedPlatform) -> Bool {
         return lhs.platform == rhs.platform && lhs.version == rhs.version
     }

--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -38,6 +38,10 @@ struct ProjectGenerator {
 
     /// Writes out the Xcconfig file
     func writeDistributionXcconfig () throws {
+        guard self.package.hasDistributionBuildXcconfig else {
+            return
+        }
+
         try makeDirectories(self.projectPath)
 
         let path = AbsolutePath(self.package.distributionBuildXcconfig.path)
@@ -56,14 +60,6 @@ struct ProjectGenerator {
                 BUILD_LIBRARY_FOR_DISTRIBUTION=YES
                 """
             )
-
-            if package.options.platform.contains(.maccatalyst) {
-                stream (
-                    """
-                    SUPPORTS_MACCATALYST=YES
-                    """
-                )
-            }
         }
     }
 

--- a/Sources/CreateXCFramework/XcodeBuilder.swift
+++ b/Sources/CreateXCFramework/XcodeBuilder.swift
@@ -122,8 +122,13 @@ struct XcodeBuilder {
             }
         }
 
+        // enable evolution for the whole stack
+        if self.options.stackEvolution {
+            command.append("BUILD_LIBRARY_FOR_DISTRIBUTION=YES")
+        }
+
         // add build settings provided in the invocation
-        options.xcSetting.forEach { setting in
+        self.options.xcSetting.forEach { setting in
             command.append("\(setting.name)=\(setting.value)")
         }
 

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -74,7 +74,7 @@ struct Zipper {
         guard let packageRef = self.package.graph.packages.first(where: { $0.targets.contains(where: { $0.name == target }) }) else { return nil }
 
         guard
-            let dependency = self.package.workspace.state.dependencies[forNameOrIdentity: packageRef.name],
+            let dependency = self.package.workspace.state.dependencies[forNameOrIdentity: packageRef.manifestName],
             case let .checkout(checkout) = dependency.state,
             let version = checkout.version
         else {

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -74,7 +74,7 @@ struct Zipper {
         guard let packageRef = self.package.graph.packages.first(where: { $0.targets.contains(where: { $0.name == target }) }) else { return nil }
 
         guard
-            let dependency = self.package.workspace.state.dependencies[forNameOrIdentity: packageRef.manifestName],
+            let dependency = self.package.workspace.state.dependencies[forNameOrIdentity: packageRef.packageName],
             case let .checkout(checkout) = dependency.state,
             let version = checkout.version
         else {
@@ -91,3 +91,17 @@ struct Zipper {
         try FileManager.default.removeItem(at: file)
     }
 }
+
+#if swift(>=5.5)
+private extension ResolvedPackage {
+    var packageName: String {
+        self.manifestName
+    }
+}
+#else
+private extension ResolvedPackage {
+    var packageName: String {
+        self.name
+    }
+}
+#endif


### PR DESCRIPTION
Previously we would enable Library Evolution (eg. `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`) only on the targets that were specified on the command line. This is to work around issues with dependencies like [swift-nio](https://github.com/apple/swift-nio) that have annotations for library evolution, but that cannot be compiled with evolution enabled, and have [no plans to support it anytime soon](https://github.com/apple/swift-nio/issues/1257).

This is can be inefficient though as it means fiddling with the targets list in order to enable library evolution when you do need it turned on for dependencies as well (eg. you can't build an XCFramework if you depend on [SwiftProtobuf](https://github.com/apple/swift-protobuf) because library evolution also raises the minimum supported platform versions).

The new option added in this PR, `--stack-evolution`, helps by turning on `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` for the entire build stack instead of just the specified targets.