### PR TITLE
Fixed GitHub Action

### DIFF
--- a/action.js
+++ b/action.js
@@ -4,7 +4,7 @@ const path = require('path')
 const artifact = require('././.action/artifact')
 const fs = require('fs')
 
-const scxVersion = '2.1.0'
+const scxVersion = 'v2.1.0'
 const outputPath = '.build/xcframework-zipfile.url'
 
 core.setCommandEcho(true)

--- a/action.js
+++ b/action.js
@@ -9,7 +9,7 @@ const outputPath = '.build/xcframework-zipfile.url'
 
 core.setCommandEcho(true)
 
-async function run () {
+async function run() {
     try {
         let packagePath = core.getInput('path', { required: false })
         let targets = core.getInput('target', { required: false })
@@ -24,7 +24,7 @@ async function run () {
         await installUsingMintIfRequired('swift-create-xcframework', 'unsignedapps/swift-create-xcframework')
 
         // put together our options
-        var options = [ '--zip', '--github-action' ]
+        var options = ['--zip', '--github-action']
         if (!!packagePath) {
             options.push('--package-path')
             options.push(packagePath)
@@ -60,7 +60,7 @@ async function run () {
                 })
         }
 
-        await exec.exec('swift-create-xcframework', options)
+        await runUsingMint('swift-create-xcframework', options)
 
         let client = artifact.create()
         let files = fs.readFileSync(outputPath, { encoding: 'utf8' })
@@ -70,7 +70,7 @@ async function run () {
         for (var i = 0, c = files.length; i < c; i++) {
             let file = files[i]
             let name = path.basename(file)
-            await client.uploadArtifact(name, [ file ], path.dirname(file))
+            await client.uploadArtifact(name, [file], path.dirname(file))
         }
 
     } catch (error) {
@@ -78,28 +78,32 @@ async function run () {
     }
 }
 
-async function installUsingBrewIfRequired (package) {
+async function installUsingBrewIfRequired(package) {
     if (await isInstalled(package)) {
         core.info(package + " is already installed.")
 
     } else {
         core.info("Installing " + package)
-        await exec.exec('brew', [ 'install', package ])
+        await exec.exec('brew', ['install', package])
     }
 }
 
-async function installUsingMintIfRequired (command, package) {
+async function installUsingMintIfRequired(command, package) {
     if (await isInstalled(command)) {
         core.info(command + " is already installed")
 
     } else {
         core.info("Installing " + package)
-        await exec.exec('mint', [ 'install', 'unsignedapps/swift-create-xcframework@' + scxVersion ])
+        await exec.exec('mint', ['install', 'unsignedapps/swift-create-xcframework@' + scxVersion])
     }
 }
 
-async function isInstalled (command) {
-    return await exec.exec('which', [ command ], { silent: true, failOnStdErr: false, ignoreReturnCode: true }) == 0
+async function isInstalled(command) {
+    return await exec.exec('which', [command], { silent: true, failOnStdErr: false, ignoreReturnCode: true }) == 0
+}
+
+async function runUsingMint(command, options) {
+    await exec.exec('mint', ['run', command, ...options])
 }
 
 run()


### PR DESCRIPTION
The current GitHub Action is failed on me due to multiple issues.

*Configuration:*

```yml
name: Publish Release

on:
  push:
    tags:
    branches: [ publish-release-automation ]

jobs:
  create_release:
    name: Create Release
    runs-on: macos-latest
    steps:
      - uses: actions/checkout@v2
      - name: Create XCFramework
        uses: philprime/swift-create-xcframework@main
```

*Encountered issues:*

- Install failed due to missing leading `v` in the version number.

```
Run philprime/swift-create-xcframework@main
Installing mint
/usr/local/bin/brew install mint
==> Downloading https://ghcr.io/v2/homebrew/core/mint/manifests/0.17.1
==> Downloading https://ghcr.io/v2/homebrew/core/mint/blobs/sha256:d09ea36619994628564fb3d7e8e71b8c368c59f68e29174fb84b9b127bd9290e
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:d09ea36619994628564fb3d7e8e71b8c368c59f68e29174fb84b9b127bd9290e?se=2021-11-17T16%3A55%3A00Z&sig=TiYL18NN4DakSQW%2BPIXsTwkjVhT%2FwRPLrF7l9A7Rar8%3D&sp=r&spr=https&sr=b&sv=2019-12-12
==> Pouring mint--0.17.1.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/mint/0.17.1: 6 files, 1.5MB
Installing unsignedapps/swift-create-xcframework
/usr/local/bin/mint install unsignedapps/swift-create-xcframework@v2.1.0
🌱 Cloning swift-create-xcframework v2.1.0
Cloning into 'github.com_unsignedapps_swift-create-xcframework'...
warning: Could not find remote branch 2.1.0 to clone.
fatal: Remote branch 2.1.0 not found in upstream origin
🌱 Encountered error during "git clone --depth 1 -b 2.1.0 https://github.com/unsignedapps/swift-create-xcframework.git github.com_unsignedapps_swift-create-xcframework". Use --verbose to see full output
🌱  Couldn't clone https://github.com/unsignedapps/swift-create-xcframework.git 2.1.0
Error: Error: The process '/usr/local/bin/mint' failed with exit code 1
```

--> Fixed by setting the correct version

- Binary `swift-create-xcframework` can't be located

```
Error: Error: Unable to locate executable file: swift-create-xcframework. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

--> Fixed by calling the binary using  the `mint run` command

This PR fixes the issues. I tested it by using my main branch in a GitHub pipeline, where checking out was successful.