### PR TITLE
Fix the issue of printing "Error: missingKey("url")" under xcode13.3 …

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
         }
       },
       {
@@ -23,8 +23,8 @@
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "ba0ab62cfc3999fb47fcfa33f046677008d9b145",
+          "branch": "release/5.6",
+          "revision": "9982f32f96a2e0e597d1b4a0af4a7e997dc471be",
           "version": null
         }
       },
@@ -32,8 +32,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "b5d9b4a9995c05688ae5f3b87a0d7ac0dc45c6c6",
+          "branch": "release/5.6",
+          "revision": "acd686530e56122d916acd49a166beb9198e9b87",
           "version": null
         }
       },
@@ -41,8 +41,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "96c347b1419e513291f07c988f3e995363d400ed",
+          "branch": "release/5.6",
+          "revision": "e399e87bd4a2984947e15edc3f6750d1f6fa5d6e",
           "version": null
         }
       },
@@ -50,8 +50,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "1b21e2ce36891ed4f458421a83b5d9e886acd4cd",
+          "branch": "release/5.6",
+          "revision": "f6c8048a76e280d0f14cc378b8b5c3cfb77c61fb",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let dependencies: [Package.Dependency]
 #if swift(>=5.5)
 dependencies = [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.4.4")),
-    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.5")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("1.0.1")),
+    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.6")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3"))
 ]
 #else
@@ -23,7 +23,7 @@ let package = Package(
 
     // TODO: Add Linux / Windows support
     platforms: [
-        .macOS(.v10_15),
+        .macOS(.v11),
     ],
 
     products: [

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -113,27 +113,27 @@ struct Command: ParsableCommand {
                 xcframeworkFiles.append((pair.key, try builder.merge(target: pair.key, buildResults: pair.value)))
             }
 
-        // zip it up if thats what they want
-        if self.options.zip {
-            let zipper = Zipper(package: package)
-            let zipped = try xcframeworkFiles
-                .flatMap { pair -> [Foundation.URL] in
-                    let zip = try zipper.zip(target: pair.0, version: self.options.zipVersion, file: pair.1)
-                    let checksum = try zipper.checksum(file: zip)
-                    try zipper.clean(file: pair.1)
-
-                    return [ zip, checksum ]
-                }
-
-            // notify the action if we have one
-            if self.options.githubAction {
-                let zips = zipped.map({ $0.path }).joined(separator: "\n")
-                let data = Data(zips.utf8)
-                let url = Foundation.URL(fileURLWithPath: self.options.buildPath).appendingPathComponent("xcframework-zipfile.url")
-                try data.write(to: url)
-            }
-
-        }
+//        // zip it up if thats what they want
+//        if self.options.zip {
+//            let zipper = Zipper(package: package)
+//            let zipped = try xcframeworkFiles
+//                .flatMap { pair -> [Foundation.URL] in
+//                    let zip = try zipper.zip(target: pair.0, version: self.options.zipVersion, file: pair.1)
+//                    let checksum = try zipper.checksum(file: zip)
+//                    try zipper.clean(file: pair.1)
+//
+//                    return [ zip, checksum ]
+//                }
+//
+//            // notify the action if we have one
+//            if self.options.githubAction {
+//                let zips = zipped.map({ $0.path }).joined(separator: "\n")
+//                let data = Data(zips.utf8)
+//                let url = Foundation.URL(fileURLWithPath: self.options.buildPath).appendingPathComponent("xcframework-zipfile.url")
+//                try data.write(to: url)
+//            }
+//
+//        }
     }
 }
 

--- a/Sources/CreateXCFramework/Command.swift
+++ b/Sources/CreateXCFramework/Command.swift
@@ -113,27 +113,27 @@ struct Command: ParsableCommand {
                 xcframeworkFiles.append((pair.key, try builder.merge(target: pair.key, buildResults: pair.value)))
             }
 
-//        // zip it up if thats what they want
-//        if self.options.zip {
-//            let zipper = Zipper(package: package)
-//            let zipped = try xcframeworkFiles
-//                .flatMap { pair -> [Foundation.URL] in
-//                    let zip = try zipper.zip(target: pair.0, version: self.options.zipVersion, file: pair.1)
-//                    let checksum = try zipper.checksum(file: zip)
-//                    try zipper.clean(file: pair.1)
-//
-//                    return [ zip, checksum ]
-//                }
-//
-//            // notify the action if we have one
-//            if self.options.githubAction {
-//                let zips = zipped.map({ $0.path }).joined(separator: "\n")
-//                let data = Data(zips.utf8)
-//                let url = Foundation.URL(fileURLWithPath: self.options.buildPath).appendingPathComponent("xcframework-zipfile.url")
-//                try data.write(to: url)
-//            }
-//
-//        }
+        // zip it up if thats what they want
+        if self.options.zip {
+            let zipper = Zipper(package: package)
+            let zipped = try xcframeworkFiles
+                .flatMap { pair -> [Foundation.URL] in
+                    let zip = try zipper.zip(target: pair.0, version: self.options.zipVersion, file: pair.1)
+                    let checksum = try zipper.checksum(file: zip)
+                    try zipper.clean(file: pair.1)
+
+                    return [ zip, checksum ]
+                }
+
+            // notify the action if we have one
+            if self.options.githubAction {
+                let zips = zipped.map({ $0.path }).joined(separator: "\n")
+                let data = Data(zips.utf8)
+                let url = Foundation.URL(fileURLWithPath: self.options.buildPath).appendingPathComponent("xcframework-zipfile.url")
+                try data.write(to: url)
+            }
+
+        }
     }
 }
 

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -78,12 +78,14 @@ struct PackageInfo {
 
         #if swift(>=5.5)
         let resources = ToolchainConfiguration(swiftCompilerPath: self.toolchain.swiftCompilerPath)
-        #else
-        let resources = try UserManifestResources(swiftCompiler: self.toolchain.swiftCompiler)
-        #endif
         let loader = ManifestLoader(toolchain: resources)
         self.workspace = try Workspace.init(forRootPackage: root, customManifestLoader: loader)
-        
+        #else
+        let resources = try UserManifestResources(swiftCompiler: self.toolchain.swiftCompiler)
+        let loader = ManifestLoader(manifestResources: resources)
+        self.workspace = Workspace.create(forRootPackage: root, manifestLoader: loader)
+        #endif
+
         #if swift(>=5.5)
         self.graph = try self.workspace.loadPackageGraph(rootPath: root, diagnostics: self.diagnostics)
         let swiftCompiler = toolchain.swiftCompiler

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -52,10 +52,17 @@ struct Zipper {
     }
 
     func checksum (file: Foundation.URL) throws -> Foundation.URL {
+#if swift(>=5.5)
         let sum = try self.package.workspace.checksum(forBinaryArtifactAt: AbsolutePath(file.path))
         let checksumFile = file.deletingPathExtension().appendingPathExtension("sha256")
         try Data(sum.utf8).write(to: checksumFile)
         return checksumFile
+#else
+        let sum = self.package.workspace.checksum(forBinaryArtifactAt: AbsolutePath(file.path), diagnostics: self.package.diagnostics)
+        let checksumFile = file.deletingPathExtension().appendingPathExtension("sha256")
+        try Data(sum.utf8).write(to: checksumFile)
+        return checksumFile
+#endif
     }
 
     private func zipCommand (source: Foundation.URL, target: Foundation.URL) -> [String] {
@@ -101,13 +108,7 @@ struct Zipper {
     }
 }
 
-#if swift(>=5.5)
-private extension ResolvedPackage {
-//    var packageName: String {
-//        self.identity
-//    }
-}
-#else
+#if swift(<5.5)
 private extension ResolvedPackage {
     var packageName: String {
         self.name


### PR DESCRIPTION
Since Xcode 13.3.1 the swift package manifest parser is broken. With Xcode 13.2 it works. The only error that's printed is: Error: missingKey("url").

### Environment:
Xcode 13.3.1 and macOS 12.3

### Steps to Reproduce
Check out https://github.com/gini/gini-mobile-ios
$ cd BankSDK/GiniBankSDK
$ swift create-xcframework

### Expected behavior
An XCFramework is generated.

### Actual behavior
Error: missingKey("url") is printed.

### Solution
I updated the SwiftPM to 5.6 in Package.swift and do some modifications to adapt to the 5.6 version of SwiftPM.