### PR TITLE
Fixed issue with missing(url) on latest XCodes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {
@@ -15,16 +15,16 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+          "version": "1.1.7"
         }
       },
       {
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "ba0ab62cfc3999fb47fcfa33f046677008d9b145",
+          "branch": "release/5.6",
+          "revision": "9982f32f96a2e0e597d1b4a0af4a7e997dc471be",
           "version": null
         }
       },
@@ -32,8 +32,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "b5d9b4a9995c05688ae5f3b87a0d7ac0dc45c6c6",
+          "branch": "release/5.6",
+          "revision": "acd686530e56122d916acd49a166beb9198e9b87",
           "version": null
         }
       },
@@ -41,8 +41,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "96c347b1419e513291f07c988f3e995363d400ed",
+          "branch": "release/5.6",
+          "revision": "286f6dc58e7211d925c3c8ef28593b45f8bfdd85",
           "version": null
         }
       },
@@ -50,8 +50,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "1b21e2ce36891ed4f458421a83b5d9e886acd4cd",
+          "branch": "release/5.6",
+          "revision": "f6c8048a76e280d0f14cc378b8b5c3cfb77c61fb",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,13 @@
 import PackageDescription
 
 let dependencies: [Package.Dependency]
-#if swift(>=5.5)
+#if swift(>=5.6)
+dependencies = [
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("1.0.3")),
+    .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.6")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.5"))
+]
+#elseif swift(>=5.5)
 dependencies = [
     .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.4.4")),
     .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.5")),
@@ -18,13 +24,22 @@ dependencies = [
 ]
 #endif
 
+let platforms: [SupportedPlatform]
+#if swift(>=5.6)
+platforms = [
+    .macOS(.v11),
+]
+#else
+platforms = [
+    .macOS(.v10_15),
+]
+#endif
+
 let package = Package(
     name: "swift-create-xcframework",
 
     // TODO: Add Linux / Windows support
-    platforms: [
-        .macOS(.v10_15),
-    ],
+    platforms: platforms,
 
     products: [
         .executable(name: "swift-create-xcframework", targets: [ "CreateXCFramework" ]),

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -63,7 +63,7 @@ struct PackageInfo {
 
     // TODO: Map diagnostics to swift-log
 #if swift(>=5.6)
-    let observabilitySystem = ObservabilitySystem { scope, diagnostics in
+    let observabilitySystem = ObservabilitySystem { _, diagnostics in
         print("\(diagnostics.severity): \(diagnostics.message)")
     }
 #else
@@ -79,7 +79,7 @@ struct PackageInfo {
 
     // MARK: - Initialisation
 
-    init (options: Command.Options) throws {
+    init (options: Command.Options) throws { // swiftlint:disable:this function_body_length
         self.options = options
         self.rootDirectory = Foundation.URL(fileURLWithPath: options.packagePath, isDirectory: true).absoluteURL
         self.buildDirectory = self.rootDirectory.appendingPathComponent(options.buildPath, isDirectory: true).absoluteURL

--- a/Sources/CreateXCFramework/PackageInfo.swift
+++ b/Sources/CreateXCFramework/PackageInfo.swift
@@ -6,14 +6,20 @@
 //
 
 import ArgumentParser
+#if swift(>=5.6)
 import Basics
+#endif
 import Build
 import Foundation
+#if swift(>=5.6)
 import PackageGraph
+#endif
 import PackageLoading
 import PackageModel
 import SPMBuildCore
+#if swift(>=5.6)
 import TSCBasic
+#endif
 import Workspace
 import Xcodeproj
 

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if swift(>=5.6)
 import PackageGraph
+#endif
 import PackageModel
 import TSCBasic
 import Workspace

--- a/Sources/CreateXCFramework/Zipper.swift
+++ b/Sources/CreateXCFramework/Zipper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import PackageGraph
 import PackageModel
 import TSCBasic
 import Workspace
@@ -51,7 +52,11 @@ struct Zipper {
     }
 
     func checksum (file: Foundation.URL) throws -> Foundation.URL {
+#if swift(>=5.6)
+        let sum = try self.package.workspace.checksum(forBinaryArtifactAt: AbsolutePath(file.path))
+#else
         let sum = self.package.workspace.checksum(forBinaryArtifactAt: AbsolutePath(file.path), diagnostics: self.package.diagnostics)
+#endif
         let checksumFile = file.deletingPathExtension().appendingPathExtension("sha256")
         try Data(sum.utf8).write(to: checksumFile)
         return checksumFile
@@ -73,6 +78,14 @@ struct Zipper {
         // find the package that contains our target
         guard let packageRef = self.package.graph.packages.first(where: { $0.targets.contains(where: { $0.name == target }) }) else { return nil }
 
+#if swift(>=5.6)
+        guard
+            let dependency = self.package.workspace.state.dependencies[packageRef.identity],
+            case let .custom(version, _) = dependency.state
+        else {
+            return fallback.flatMap { "-" + $0 }
+        }
+#else
         guard
             let dependency = self.package.workspace.state.dependencies[forNameOrIdentity: packageRef.packageName],
             case let .checkout(checkout) = dependency.state,
@@ -80,6 +93,7 @@ struct Zipper {
         else {
             return fallback.flatMap { "-" + $0 }
         }
+#endif
 
         return "-" + version.description
     }
@@ -92,7 +106,9 @@ struct Zipper {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.6)
+// Intentionally left blank
+#elseif swift(>=5.5)
 private extension ResolvedPackage {
     var packageName: String {
         self.manifestName


### PR DESCRIPTION
This PR is following-up the previously opened (but inactive) https://github.com/unsignedapps/swift-create-xcframework/pull/64

Since Xcode 13.3.1 the swift package manifest parser is broken (as per issue #63). The latest version of Xcode it works with is 13.2.1. The only error that's printed is: `Error: missingKey("url")`.

Environment:

Xcode 13.3.1 and macOS 12.3

Steps to Reproduce

Check out https://github.com/gini/gini-mobile-ios
$ cd BankSDK/GiniBankSDK
$ swift create-xcframework

Expected behavior

An XCFramework is generated.

Actual behavior

Error: `missingKey("url")` is printed.

Solution:

Update dependencies to support Swift 5.6 and adopt changes in the codebase.