### PR TITLE
Fix #88: disable ENABLE_TESTABILITY for release mode

### DIFF
--- a/Sources/CreateXCFramework/ProjectGenerator.swift
+++ b/Sources/CreateXCFramework/ProjectGenerator.swift
@@ -103,6 +103,10 @@ struct ProjectGenerator {
         )
 #endif
 
+        for target in project.targets {
+            target.buildSettings.release.ENABLE_TESTABILITY = "NO"
+        }
+
         return project
     }
 


### PR DESCRIPTION
Fixes https://github.com/unsignedapps/swift-create-xcframework/issues/88. It now reset `ENABLE_TESTABILITY` to the same values as the default ones from Xcode: `YES` for Debug, `NO` for Release.